### PR TITLE
docs: production deploy runbook + 2026-06-26 cache-deadlock incident

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -5,4 +5,5 @@ nav:
   - Maintenance: maintenance
   - Architecture Decisions: adr
   - Troubleshooting: troubleshooting
+  - Incidents: incidents
   - Session Logs: session-logs

--- a/docs/incidents/.pages
+++ b/docs/incidents/.pages
@@ -1,0 +1,3 @@
+nav:
+  - README.md
+  - 2026-06-26-prod-cache-deadlock-wsod.md

--- a/docs/incidents/2026-06-26-prod-cache-deadlock-wsod.md
+++ b/docs/incidents/2026-06-26-prod-cache-deadlock-wsod.md
@@ -1,0 +1,96 @@
+# 2026-06-26 — Production WSOD during rolling deploy (shared-cache deadlock)
+
+**Severity:** brief partial outage (WSOD) on production
+**Duration:** short — a single fatal at 11:14:50 EDT, cleared by a manual `drush cr`
+**Trigger:** manual `drush cr` on one node while the other served live traffic
+**Status:** resolved; preventive changes captured below
+
+## Summary
+
+During the manual rolling deploy of `build-20260625193203` (the SimpleSAMLphp
+secure-cookie fix + `block_class` 3.0.0), `library.virginia.edu` served a **White Screen of
+Death** for a period. The site was restored by running `drush cr`. Root cause: a **database
+deadlock on the shared cache**, triggered by rebuilding cache on one node while the other
+node was serving all live production traffic.
+
+## Timeline (EDT)
+
+| Time | Event |
+|------|-------|
+| ~10:50 | Node 1 drained from ALB; node 0 serving 100% |
+| ~11:00 | Node 1 deployed (new image) |
+| ~11:04 | `drush cr` run on node 1 (out of rotation, but **shares DB cache with live node 0**) |
+| ~11:05 | Node 1 re-added, healthy |
+| ~11:06 | Node 0 drained; **node 1 now serving 100%** |
+| ~11:13 | Node 0 deployed |
+| **11:14:50** | **`drush cr` on node 0 collides with node 1's live traffic → deadlock → fatal on node 1 → WSOD** |
+| ~11:15 | Node 0 re-added; manual `drush cr` clears the cached error page |
+
+## Evidence
+
+One uncaught fatal in node 1's container log, at 11:14:50 EDT:
+
+```
+Uncaught PHP Exception Drupal\Core\Database\DatabaseExceptionWrapper:
+"SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock;
+ try restarting transaction: INSERT INTO "cache_entity" (...)"
+```
+
+- Exactly **one** deadlock fatal logged, on `cache_entity`. None before or since.
+- Cache backend confirmed: **default database cache**, no Redis/Memcache enabled →
+  all `cache_*` bins live in the shared RDS database, written by **both** nodes.
+
+## Root cause
+
+1. The two production nodes share **one database cache backend**.
+2. `drush cr` is a **mass write** (bulk `INSERT`/`DELETE`) to the shared `cache_*` tables.
+3. Running it on node 0 while **node 1 served live traffic** put two concurrent writers on
+   the same `cache_entity` InnoDB rows → **deadlock (SQLSTATE 40001 / 1213)**. InnoDB chose
+   node 1's transaction as the victim and rolled it back.
+4. Drupal did not retry the cache write; the exception bubbled up **uncaught** → fatal.
+5. **Why one fatal looked like a sustained outage:** the broken render was stored in the
+   page/dynamic-page cache and re-served to subsequent visitors (cache hits = no new PHP =
+   no new log lines). The manual `drush cr` flushed the cached bad page, restoring the site.
+
+### The misconception that enabled it
+
+The team's practice was *"`drush cr` each node while it's offline."* But **"offline" only
+means out of the ALB** — the node still shares the database cache with the live node. So a
+cache rebuild on the drained node still collides with live traffic on the shared cache
+tables. Draining isolates HTTP, not the cache.
+
+(The same shared-cache root cause produced a benign symptom earlier in the deploy:
+`drush pm:list` reported `block_class 2.0.12` even after a `cr`, because the still-old node
+kept repopulating the shared discovery cache. The on-disk code was correct.)
+
+## Resolution
+
+`drush cr` after both nodes were on the new image (no competing writer) rebuilt the cache
+cleanly and flushed the cached error page.
+
+## Corrective actions
+
+**Immediate (done):**
+
+- [Production deploy runbook](../operations/production-deploy-runbook.md) rewritten:
+  **never** `drush cr` on one node while the other serves live traffic; do **one** `cr` at
+  the end after both nodes are upgraded, or under maintenance mode for structural changes.
+
+**Follow-up (the real fix):**
+
+- [ ] **Move the cache off the shared database to Redis (or Memcache).** Redis handles
+  concurrent writes without SQL row locks, eliminating this entire deadlock class. This is
+  the standard multi-node Drupal production setup and the highest-value change. Tracked in
+  [Redis cache backend](../maintenance/redis-cache-backend.md).
+
+**Defensive (lower priority):**
+
+- [ ] Consider deadlock-retry on cache writes and/or not caching error renders. Largely
+  moot once Redis lands.
+
+## Related
+
+- [Production deploy runbook](../operations/production-deploy-runbook.md)
+- [Redis cache backend](../maintenance/redis-cache-backend.md)
+- [SimpleSAMLphp secure cookie](../troubleshooting/simplesamlphp-secure-cookie.md) — the fix
+  this deploy was shipping

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -1,0 +1,9 @@
+# Incidents
+
+Post-mortems for production incidents: what happened, the root cause, and what changed as a
+result. An incident note records *what went wrong once*; the
+[runbooks](../operations/README.md) record the *corrected procedure* that came out of it.
+
+| Date | Incident | Root cause |
+|------|----------|-----------|
+| 2026-06-26 | [Production WSOD during rolling deploy](2026-06-26-prod-cache-deadlock-wsod.md) | Database deadlock on the shared cache (`drush cr` on one node while the other served live traffic) |

--- a/docs/maintenance/.pages
+++ b/docs/maintenance/.pages
@@ -4,3 +4,4 @@ nav:
   - ckeditor4-to-ckeditor5.md
   - drupal-11-upgrade.md
   - config-sync-mechanism-review.md
+  - redis-cache-backend.md

--- a/docs/maintenance/README.md
+++ b/docs/maintenance/README.md
@@ -9,6 +9,7 @@ version upgrade.
 | Removing CKEditor 4, migrating to CKEditor 5 | [CKEditor 4 → 5](ckeditor4-to-ckeditor5.md) |
 | Drupal 10 → 11 upgrade | [Drupal 11 upgrade](drupal-11-upgrade.md) |
 | Config-sync export mechanism (review/redesign) | [Config-sync mechanism review](config-sync-mechanism-review.md) |
+| Move cache off the shared DB to Redis (real fix for deploy deadlocks) | [Redis cache backend](redis-cache-backend.md) |
 
 ## Validation / smoke tests
 

--- a/docs/maintenance/redis-cache-backend.md
+++ b/docs/maintenance/redis-cache-backend.md
@@ -1,0 +1,51 @@
+# Redis Cache Backend (follow-up)
+
+**Status:** proposed — not yet implemented
+**Priority:** high (real fix for the [2026-06-26 cache-deadlock WSOD](../incidents/2026-06-26-prod-cache-deadlock-wsod.md))
+
+## Problem
+
+Production runs **two nodes** sharing a **single database cache backend** (Drupal's
+default; no Redis/Memcache). All `cache_*` bins live in the shared RDS database and are
+written by both nodes. Under concurrency — especially a `drush cr` mass-write on one node
+while the other serves live traffic — the nodes deadlock on the same InnoDB cache rows
+(`SQLSTATE 40001 / 1213`), producing uncaught fatals and a WSOD. This happened during the
+2026-06-26 production deploy.
+
+The [deploy runbook](../operations/production-deploy-runbook.md) now works around it
+procedurally (single `cr` at the end / maintenance mode), but the procedure is fragile —
+the database cache is simply not appropriate for a multi-node site at this traffic level.
+
+## Proposed fix
+
+Add a shared **Redis** (or Memcache) cache backend so cache reads/writes leave the
+relational database entirely. Redis handles concurrent writes without SQL row locks, which
+**eliminates this deadlock class** and removes the "don't `cr` while the other node serves
+traffic" constraint.
+
+Rough shape (to be spiked, not prescriptive):
+
+- Provision a Redis endpoint (ElastiCache) reachable from both nodes — Terraform in
+  `terraform-infrastructure/library.virginia.edu/`.
+- `composer require drupal/redis`; enable the module.
+- Point the cache backend at Redis in `settings.php`
+  (`$settings['redis.connection']`, `$settings['cache']['default'] = 'cache.backend.redis'`),
+  injected via the container environment alongside the other prod settings.
+- Keep `cache_form` and anything requiring consistency on a safe backend per Drupal's
+  Redis module guidance.
+
+## Notes / caveats
+
+- A **shared** Redis still has the harmless version-skew display quirk mid-deploy (the
+  discovery cache reflects whichever node wrote last) — but **not** the WSOD-class deadlock,
+  which is the part that caused the outage.
+- Verify behavior on staging first; staging is single-node, so load-test the concurrent
+  case deliberately.
+- Revisit the deploy runbook once this lands — the maintenance-mode requirement for
+  structural changes can likely be relaxed.
+
+## Related
+
+- [Incident: 2026-06-26 cache-deadlock WSOD](../incidents/2026-06-26-prod-cache-deadlock-wsod.md)
+- [Production deploy runbook](../operations/production-deploy-runbook.md)
+- [Deploy strategy exploration](../operations/deploy-strategy-exploration.md) — the broader rolling/blue-green analysis and where Redis fits

--- a/docs/operations/.pages
+++ b/docs/operations/.pages
@@ -3,3 +3,5 @@ nav:
   - local-development.md
   - syncing-data.md
   - deployment.md
+  - production-deploy-runbook.md
+  - deploy-strategy-exploration.md

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -7,3 +7,5 @@ Running and maintaining the library.virginia.edu Drupal site.
 | Local development with DDEV | [Local development](local-development.md) |
 | Pulling remote DB / files into a local environment | [Syncing data](syncing-data.md) |
 | Build & deploy pipeline (AWS CodeBuild) | [Deployment](deployment.md) |
+| Manual zero-downtime production deploy (step by step) | [Production deploy runbook](production-deploy-runbook.md) |
+| Why rolling/blue-green works (or doesn't) here; future options | [Deploy strategy exploration](deploy-strategy-exploration.md) |

--- a/docs/operations/deploy-strategy-exploration.md
+++ b/docs/operations/deploy-strategy-exploration.md
@@ -1,0 +1,175 @@
+# Deployment Strategy — Exploration & Open Questions
+
+!!! note "Status: exploration, not a decision"
+    This is a **thinking record** for future exploration and discussion — not an accepted
+    decision (no ADR yet) and not an operational procedure. The procedure in force is the
+    [production deploy runbook](production-deploy-runbook.md); the concrete near-term fix is
+    [Redis cache backend](../maintenance/redis-cache-backend.md). This page captures *why*
+    those are the frontier and what the bigger moves would cost, so the reasoning isn't
+    re-litigated from scratch. Prompted by the
+    [2026-06-26 cache-deadlock WSOD](../incidents/2026-06-26-prod-cache-deadlock-wsod.md).
+
+## The core principle
+
+Production runs **two nodes against shared state** (one RDS database — content, config,
+schema; the cache; Solr). Every "can we deploy this without downtime?" question reduces to
+a single axis:
+
+> **Can node-old and node-new run *simultaneously* against the shared state without either
+> one breaking?**
+
+A node's own code/theme/Apache/PHP live in the container image and are *not* shared, so they
+never block a rolling deploy. Only **shared, authoritative** state does. The rest of this
+doc is consequences of that one question.
+
+## A change taxonomy (the practical decision rule)
+
+For any change, ask in order:
+
+1. **Mutates shared DB schema/data non-additively?** → effectively **downtime**
+   (maintenance/read-only window) *unless* decomposed via expand/contract.
+2. **Mutates shared config?** → **rolling if made coexistence-safe**: determine
+   compatibility direction, apply the shared change on the compatible side of the roll.
+3. **Node-local only and needs no `drush cr`?** → **pure rolling**, any order.
+4. **Node-local but needs a `cr`?** → class-3-style coupling sneaks in via the **shared
+   cache**: one `cr` at the end (or Redis). The code change is trivial; the cache rebuild is
+   the coupling.
+
+This supersedes a "big vs small change" intuition. The driving question is *what shared
+state does this touch, and can N and N+1 coexist against it* — answerable up front, per
+change.
+
+### Worked example: the 2026-06-26 deploy
+
+A **mix** of class 1 (the Apache `HTTPS=on` line — node-local) and class 2 (`block_class`
+2→3 — a contrib major bump with a config schema change). It was rollable **only because**
+`block_class` 3 had *no pending `updb`* (additive config, no data migration). One destructive
+update hook and it would have been class 3. The WSOD came from the class-4 trap above: a
+per-node `cr` against the shared DB cache while the other node served live traffic.
+
+## Making class 2 rolling
+
+- **Compatibility direction.** Either old code tolerates new config (*backward-compatible* →
+  apply shared change first, then roll code) or new code tolerates old (*forward-compatible*
+  → roll code first, apply shared change last). Additive config with defaults is usually
+  backward-compatible; renames/removals are not.
+- **Make config import an explicit, ordered step** — not an implicit side effect of the
+  container swap — placed on the compatible side of the roll.
+- **Expand/contract (parallel change)** for anything not naturally compatible. This is what
+  collapses the boundary between class 2 and class 3:
+  1. **Expand** — add new schema/config additively (nullable column, new table, new key);
+     old code ignores it.
+  2. **Migrate/backfill** data.
+  3. **Transition** — deploy code that reads the new shape.
+  4. **Contract** — remove the old shape/code.
+
+  Each deploy is individually rolling; the *sequence* accomplishes a breaking change with
+  zero downtime. Cost: 2–4 deploys + discipline.
+
+## The hard case: class 3 and DB-level approaches
+
+### Why not blue-green the whole site
+
+The DB is a **shared singleton**. You can't stand up a parallel "green" Drupal because it
+would share (or fork) the one database — so a brief maintenance/read-only pause beats trying
+to blue-green a stateful site. Keep the pause short; don't over-engineer around it.
+
+### The DB blue-green idea (explored, parked)
+
+**The proposal:** fork a DB replica, suspend replication, run the migration on the offline
+(green) DB + new-code node, then cut the nodes over and let the replica "catch up."
+
+**Why it doesn't catch up — the merge constraint.** Two DBs diverge in *different
+dimensions* at once: the master keeps taking live **data** writes (old schema); the forked
+replica gets new **schema**. Once DDL has run on the replica, **normal replication can't
+resume** — the master's binlog events don't cleanly apply to the diverged shape, and even if
+they did, those writes carry *old-schema semantics* and would need re-running through the
+migration logic. That's CDC/forward-migration of the delta, not replication catch-up. It
+only works cleanly if the cutover window is **write-free** (but then a short read-only freeze
++ in-place migration does the same job, and the blue-green bought nothing), or if you build
+**delta reconciliation** (heavy — Debezium-class).
+
+**The managed version: AWS RDS Blue/Green Deployments.** This is the proposal productized
+(we're on RDS/MariaDB). Green is a clone kept *continuously* in sync via logical replication;
+switchover blocks writes for ~sub-minute, confirms catch-up, flips endpoints. Crucially it
+**only supports replication-compatible changes** (additive columns, indexes, minor-version
+bumps) — *for exactly the merge reason above*. So it doesn't repeal the compatibility
+question; it gives a clean cutover *once the change is already expand-shaped*. The mapping is
+exact: **replication-safe ≈ additive/expand ≈ rolling-safe.**
+
+**The decisive blocker for us: shared instance.** Our RDS instance hosts **several
+projects' databases**. The binlog is a single whole-server stream, so a managed replica is
+necessarily a copy of the *entire* instance — RDS Blue/Green is **all-or-nothing across every
+database on the box**. A library deploy would force an unrequested whole-instance cutover:
+co-tenants inherit the merge problem for data we aren't changing, plus cross-team
+coordination for a routine push. The instance is simply the **wrong unit** of blue-green.
+
+### What works on a shared instance instead
+
+- **Online-DDL tools** — operate in-place on *your* tables only, no instance cutover.
+  **gh-ost** (reads the binlog; lighter on a shared box) is generally friendlier than
+  **pt-online-schema-change** (triggers add write overhead + metadata locks that can degrade
+  neighbors). Right tool when a breaking *schema* change genuinely must be online.
+- **Expand/contract** at the app layer — cheapest, no special infra, naturally
+  project-scoped, and (not coincidentally) produces exactly the additive changes RDS
+  Blue/Green *would* accept if the instance weren't shared.
+
+### Drupal-specific friction
+
+`hook_update_N` mixes **schema DDL and PHP data transforms**. Online-DDL tools and RDS B/G
+handle the DDL-shaped part; they do nothing for the data-transform part, which still has to
+be authored additively. So even with DB blue-green in hand, you're back to writing update
+hooks that old code tolerates. Most contrib update hooks are *not* written this way — which
+is why a contrib major bump with an update hook is usually genuinely class 3.
+
+## Redis's role — derived vs. authoritative state
+
+Redis sharpens the same distinction: **color-separate the things cheap to rebuild; share (or
+reconcile) the things that are authoritative.**
+
+- **Cache is derived.** Give green its own Redis **prefix**, warm it, discard blue's. The
+  Drupal `redis` module supports a cache prefix, so this is clean and avoids re-creating the
+  2026-06-26 bug. Cache color-separation is **logical** (a prefix), not an instance cutover —
+  so it sidesteps the shared-infra all-or-nothing problem entirely, even on a shared
+  ElastiCache. One place the shared infra doesn't bite.
+- **Sessions, locks, semaphore, queue are authoritative-ish.** If those live in Redis and
+  green gets a fresh prefix, everyone is logged out at cutover and in-flight locks/queue
+  items vanish. Keep those on a *shared* backend across colors (or in the DB); only
+  color-separate the cache.
+
+This loops back to the core principle: blue-green is clean exactly to the extent the changing
+state is **derived**. Schema/data and sessions are **authoritative** — and authoritative
+shared state can't be forked-and-merged for free. That's why class 3 resists rolling,
+restated at the infrastructure layer.
+
+## Bottom line — the recommended frontier (in order)
+
+1. **Redis cache backend** — kills the cache-coexistence deadlock class; logical/prefix
+   scoping means the shared instance doesn't block it. ([follow-up](../maintenance/redis-cache-backend.md))
+2. **Expand/contract discipline** — makes the rare breaking change rolling-safe (and
+   RDS-Blue/Green-shaped, should that ever become available).
+3. **Online-DDL (gh-ost)** — for a breaking *schema* change that genuinely must be online,
+   without an instance cutover.
+4. **Short read-only / maintenance window** — for the genuinely-coupled remainder. Accept
+   it; keep it short.
+
+Full DB blue-green is **off the table while the DB instance is shared** — the granularity
+mismatch is fundamental, not a tuning problem.
+
+## Open questions for future exploration
+
+- **De-share the DB instance?** Giving the library project its own instance/cluster would
+  re-enable per-project RDS Blue/Green *and* address blast radius, noisy-neighbor contention,
+  independent right-sizing, and upgrade autonomy. Blue-green is only one symptom of the
+  shared-instance coupling; the de-sharing decision deserves its own cost/benefit on those
+  merits, not a deploy-mechanics justification alone. Candidate for a future ADR.
+- **Read-only mode for Drupal** — how cleanly can the site run write-blocked (anonymous
+  browsing intact) to shrink class-3 windows? Worth a small spike.
+- **Where does Solr's shared schema sit** on the same coexistence axis for search-affecting
+  deploys? Not analyzed here.
+
+## Related
+
+- [Production deploy runbook](production-deploy-runbook.md)
+- [Incident: 2026-06-26 cache-deadlock WSOD](../incidents/2026-06-26-prod-cache-deadlock-wsod.md)
+- [Redis cache backend](../maintenance/redis-cache-backend.md)

--- a/docs/operations/production-deploy-runbook.md
+++ b/docs/operations/production-deploy-runbook.md
@@ -1,0 +1,198 @@
+# Production Deploy Runbook
+
+!!! info "What is a *runbook*?"
+    A **runbook** is a step-by-step operational procedure for a routine-but-risky task —
+    the exact commands to run, in order, with the checks and decision points in between.
+    It's the difference between "we know how to deploy" (in someone's head) and "anyone on
+    the team can deploy safely by following these steps." A runbook captures the *how*; an
+    [incident note](../incidents/README.md) captures *what went wrong once* and what we
+    changed because of it. This page is the how; it was rewritten after the
+    [2026-06-26 cache-deadlock WSOD](../incidents/2026-06-26-prod-cache-deadlock-wsod.md).
+
+## When this applies
+
+Production (`library.virginia.edu`) runs **two nodes** behind an ALB
+(`library-drupal-0`, `library-drupal-1`), both serving the `drupal-0` container. Unlike
+staging — where a push to `main` auto-deploys — **production is deployed manually** by
+running the Ansible backend playbook against each node, then rotating it through the load
+balancer.
+
+This runbook covers a **zero-downtime rolling deploy**: one node out of the ALB at a time,
+so the site stays up throughout.
+
+## The one rule that matters: do not rebuild cache while the other node serves traffic
+
+!!! danger "Shared database cache"
+    Both nodes share a **single database cache backend** (no Redis/Memcache — see the
+    [Redis follow-up](../maintenance/redis-cache-backend.md)). A `drush cr` is a mass write
+    to the shared `cache_*` tables. If you run it on one node **while the other node is
+    serving live traffic**, the two collide on the same InnoDB rows and MySQL throws a
+    **deadlock (SQLSTATE 40001 / errno 1213)**. The uncaught fatal renders a broken page,
+    which then gets cached and served → **WSOD**. This caused the
+    [2026-06-26 incident](../incidents/2026-06-26-prod-cache-deadlock-wsod.md).
+
+    **"Out of the ALB" is *not* "isolated."** A drained node still shares the database
+    cache with the live node. Draining protects HTTP traffic, not the cache.
+
+Consequences for the procedure below:
+
+- **Pure code/config swap (no cache rebuild needed):** roll the nodes, skip `drush cr`.
+- **Change that needs a cache rebuild** (module major-version bump, core update, anything
+  altering services/plugins/entity definitions): do **one** `drush cr` at the **end**,
+  after both nodes are on the new image — ideally in a **low-traffic window**, or under
+  **maintenance mode** (see [Structural changes](#structural-changes-maintenance-mode)).
+  Do **not** `drush cr` per-node mid-rollout.
+
+## Preconditions
+
+- On the **UVA VPN** (hostnames won't resolve otherwise).
+- `aws-vault` configured; the `staging` profile has the needed access (yes, prod uses the
+  `staging` profile — that's how the favorite and the deploy are wired).
+- Know the **deploy tag** you're shipping. The current `latest` build tag:
+  ```bash
+  aws-vault exec staging -- aws ssm get-parameter \
+    --name "/containers/uvalib/drupal-library/latest" \
+    --query 'Parameter.Value' --output text
+  ```
+  Confirm the image's source commit before shipping:
+  ```bash
+  aws-vault exec staging -- aws ecr describe-images \
+    --repository-name uvalib/drupal-library \
+    --image-ids imageTag=<deploy_tag> \
+    --query 'imageDetails[0].imageTags' --output text   # includes gitcommit-<sha>
+  ```
+
+## Tools
+
+- **`alb-state`** — `/Users/ys2n/Code/scripts/uvalib/aws/alb-state`; favorite `drupal-prod`
+  targets `alb-library-drupal-production`. Adds/removes nodes from the ALB target group,
+  refuses to empty the pool, and `--watch` polls until health stabilizes.
+- **Ansible** — `terraform-infrastructure/library.virginia.edu/production/ansible/`,
+  `deploy_backend.yml`, run with `-e deploy_tag=<tag>` and `--limit <node>`.
+
+## Rolling deploy — step by step
+
+Do node 1 first, then node 0 (so node 0 keeps serving while node 1 deploys). Repeat the
+whole block for the second node.
+
+### 0. Baseline
+
+```bash
+cd /Users/ys2n/Code/scripts/uvalib/aws
+./alb-state drupal-prod          # confirm BOTH nodes healthy before starting
+```
+
+### 1. Drain the node from the ALB
+
+```bash
+./alb-state drupal-prod --remove uva-library-drupal-production-1 --watch --interval 30
+```
+
+`--watch` holds until the node fully drains (the **deregistration delay is 300s**), then
+prints "All targets are in a stable state." Wait for that — draining lets in-flight
+requests finish before the container is swapped.
+
+### 2. Deploy the new image to that node only
+
+```bash
+cd /Users/ys2n/Code/uvalib/terraform-infrastructure/library.virginia.edu/production/ansible
+aws-vault exec staging -- ansible-playbook deploy_backend.yml \
+  -e deploy_tag=<deploy_tag> --limit uva-library-drupal-production-1
+```
+
+Expect `failed=0` in the PLAY RECAP. The `"…saml-staging.pem missing"` line is a
+pre-existing **non-fatal** warning from the backend playbook (the NetBadge SP is a separate
+container) — ignore it.
+
+### 3. Verify the node directly (out of rotation)
+
+Hit the node **directly on `:8080`** — this checks *that specific node*, bypassing the ALB:
+
+```bash
+curl -s -o /dev/null -w 'HTTP %{http_code}  %{time_total}s\n' \
+  http://library-drupal-1.internal.lib.virginia.edu:8080/      # 200; first hit is cold/slow
+```
+
+On the node, confirm the image and any change-specific expectations:
+
+```bash
+ssh library-drupal-1.internal.lib.virginia.edu '
+  sudo docker ps --format "{{.Image}} {{.Names}}" | grep drupal-0       # = your deploy_tag
+  sudo docker exec drupal-0 grep -i X-Forwarded-Proto \
+    /etc/apache2/sites-enabled/000-default.conf                          # change-specific
+'
+```
+
+!!! warning "Do NOT run `drush cr` here"
+    See [the one rule](#the-one-rule-that-matters-do-not-rebuild-cache-while-the-other-node-serves-traffic).
+    Verifying module versions with `drush pm:list` at this point is also unreliable — the
+    shared cache reflects whichever node wrote last, so a half-rolled deploy shows the
+    *old* version even though the new code is on disk. Trust the on-disk `.info.yml`, not
+    `pm:list`, until the rollout is complete.
+
+### 4. Re-add the node to the ALB
+
+```bash
+cd /Users/ys2n/Code/scripts/uvalib/aws
+./alb-state drupal-prod --add uva-library-drupal-production-1 --watch --interval 30
+```
+
+`--watch` holds until the node is `healthy` (health check is **120s interval × 2** ≈ up to
+4 min from cold). Do not proceed to the other node until this node is healthy — that's what
+keeps the pool from going empty.
+
+### 5. Repeat for node 0
+
+Same five steps with `uva-library-drupal-production-0` /
+`library-drupal-0.internal.lib.virginia.edu`.
+
+### 6. Single cache rebuild at the end (only if the change needs it)
+
+After **both** nodes are on the new image — and ideally in a low-traffic window:
+
+```bash
+ssh library-drupal-0.internal.lib.virginia.edu \
+  'sudo docker exec drupal-0 /opt/drupal/vendor/bin/drush cr'
+```
+
+The cache is shared, so one `cr` covers both nodes. Now `drush pm:list` will report the
+correct (new) versions. If the change has database updates, run `drush updb` here too.
+
+### 7. Final verification
+
+```bash
+# Both nodes healthy in the ALB:
+/Users/ys2n/Code/scripts/uvalib/aws/alb-state drupal-prod
+# Public endpoint through the load balancer:
+curl -s -o /dev/null -w 'HTTP %{http_code}\n' https://library.virginia.edu/
+```
+
+## Structural changes — maintenance mode
+
+For module **major-version** bumps, **core** updates, or anything changing
+services/plugins/entity definitions, the safest path avoids serving live traffic against a
+mid-rebuild cache entirely:
+
+1. `drush state:set system.maintenance_mode 1` (and `drush cr`).
+2. Deploy **both** nodes (steps 1–5, but you can drain both since the site is in
+   maintenance).
+3. **One** `drush cr` (+ `drush updb` if needed).
+4. `drush state:set system.maintenance_mode 0`.
+
+This trades a short, controlled pause for eliminating the deadlock/WSOD risk. Until the
+[Redis cache backend](../maintenance/redis-cache-backend.md) lands, prefer this for any
+deploy that must rebuild cache.
+
+## Rollback
+
+Re-deploy the previous tag the same way (rolling, per node). The prior production tag
+before a deploy is whatever the nodes were running — capture it from
+`sudo docker ps` **before** you start. Releases are tracked by
+[ECR image tags, not git tags](deployment.md#release-tracking).
+
+## Related
+
+- [Incident: 2026-06-26 cache-deadlock WSOD](../incidents/2026-06-26-prod-cache-deadlock-wsod.md)
+- [Redis cache backend (follow-up / real fix)](../maintenance/redis-cache-backend.md)
+- [Deployment pipeline overview](deployment.md)
+- Host/SSH details are in the repo `CLAUDE.md`.

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -7,3 +7,4 @@ Known issues and their fixes.
 | `drush sql-dump` fails with TLS error 2026 / self-signed cert | [MariaDB SSL dump](mariadb-ssl-dump.md) |
 | SimpleSAMLphp `session.cookie.secure` error on the HTTP container | [SimpleSAMLphp secure cookie](simplesamlphp-secure-cookie.md) |
 | DDEV refuses to run the project from this directory | [DDEV one name per directory](ddev-one-name-per-directory.md) |
+| WSOD / cache `INSERT` deadlock (`SQLSTATE 40001` / 1213) after a deploy | [Incident: 2026-06-26 cache-deadlock WSOD](../incidents/2026-06-26-prod-cache-deadlock-wsod.md) |


### PR DESCRIPTION
## What

Documentation only — captures the operational knowledge from today's manual production deploy of the SimpleSAMLphp secure-cookie fix and the WSOD incident that occurred during it.

### New
- **`operations/production-deploy-runbook.md`** — step-by-step zero-downtime rolling deploy (drain → deploy `--limit` → direct `:8080` verify → re-add, per node), using `alb-state` + Ansible. Includes the corrected cache rule and a maintenance-mode variant for structural changes. (Defines "runbook" up top.)
- **`incidents/`** — new section. `2026-06-26-prod-cache-deadlock-wsod.md` post-mortems the shared-DB-cache deadlock (`SQLSTATE 40001 / 1213` on `cache_entity`) caused by running `drush cr` on one node while the other served live traffic.
- **`maintenance/redis-cache-backend.md`** — the real fix (cache off the shared DB → Redis), tracked as a follow-up.
- **`operations/deploy-strategy-exploration.md`** — synthesized reasoning record (rolling vs blue-green, expand/contract, RDS Blue/Green + the shared-instance blocker, Redis's role). Marked **exploration, not a decision**.

### Wiring
Nav (`.pages`) + index/README tables updated, plus a Troubleshooting pointer for the deadlock symptom. All four docs cross-link.

## Why
The WSOD root cause and the corrected rolling-deploy procedure only lived in one session; this puts them on record before the next manual prod deploy.

## Scope
Docs only — no code/config. The held-back `CLAUDE.md` and CKEditor-4 `composer` changes are intentionally **not** included.

## Follow-up
The **Redis cache backend** is the actual fix; the runbook is a workaround. Tracked in `maintenance/redis-cache-backend.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)