### PR TITLE
docs: prod SAML verification, host-SSH section & session logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,29 @@ Releases are tracked by ECR image tags (not git tags).
 - `SIMPLESAMLPHP_CONFIG_DIR=/var/simplesamlphp/config` is set as an Apache `SetEnv`.
 - APCu is installed via `pecl install apcu` in the Dockerfile (no version pin).
 
+## Connecting to environment hosts (SSH)
+
+All hosts are on `*.internal.lib.virginia.edu` and require the **UVA VPN** (without it, the names won't even resolve). SSH is key-based; over VPN a plain `ssh <host>` works. Use `-o BatchMode=yes` for non-interactive checks so it fails fast instead of hanging on a prompt.
+
+| Env | Host | Notes |
+|-----|------|-------|
+| **staging** | `library-drupal-staging-0.internal.lib.virginia.edu` | instance `uva-library-drupal-staging-0`, IP `10.130.109.122` |
+| **dev** | `library-drupal-develop-0.internal.lib.virginia.edu` | single node |
+| **prod (node 0)** | `library-drupal-0.internal.lib.virginia.edu` | instance `uva-library-drupal-production-0`, IP `10.130.110.83` |
+| **prod (node 1)** | `library-drupal-1.internal.lib.virginia.edu` | instance `uva-library-drupal-production-1`, IP `10.130.110.179` |
+
+**Production runs two nodes** behind the ALB (`instance_count = 2`), both running the `drupal-0` container. When verifying a prod deploy, check **both** hosts. Staging and dev are single-node.
+
+- A push to `main` deploys to **staging** (the deploy CodeBuild project runs `pipeline/deployspec.yml` → Terraform/Ansible in `terraform-infrastructure/library.virginia.edu/staging`).
+- The Drupal container is named **`drupal-0`**; the NetBadge SP container is **`netbadge-0`**. Run commands inside it with e.g. `ssh <host> 'sudo docker exec drupal-0 <cmd>'`.
+- Authoritative source for hostnames/IPs: the generated inventory/tfvars under `terraform-infrastructure/library.virginia.edu/<env>/ansible/` (e.g. `inventory.generated`, `tfvars.*.generated`). The `staging` dir may contain a stale `staging-1` tfvars — `instance_count` is 1, so only `staging-0` is real.
+- Example — verify the deployed Apache vhost on staging:
+  ```bash
+  ssh library-drupal-staging-0.internal.lib.virginia.edu \
+    'sudo docker exec drupal-0 cat /etc/apache2/sites-enabled/000-default.conf'
+  ```
+- The running container's image tag (e.g. `build-20260625181816`) is shown by `sudo docker ps`; the timestamp matches the builder's start time, letting you confirm which commit is live.
+
 ## What to edit in this repo
 
 - **Drupal dependencies:** `package/data/opt/drupal/composer.json` and `composer.lock`

--- a/docs/maintenance/staging-saml-standardization-followup.md
+++ b/docs/maintenance/staging-saml-standardization-followup.md
@@ -1,0 +1,48 @@
+# Follow-up: Standardize SimpleSAMLphp config-as-code on staging (and prod)
+
+**Status:** open follow-up (deferred 2026-06-25)
+**Repo:** `uvalib/terraform-infrastructure` → `library.virginia.edu/staging/ansible/`
+
+## Background
+
+The `develop` deploy playbook was reworked (commit `a2bc6ec36`, 2026-04-10, xw5d:
+*"Updated deploy_backend.yml … to use new environment handling and to deploy
+simplesamlphp"*) to manage SimpleSAMLphp configuration **as version-controlled code**.
+This was **never ported to `staging`** (or production). On 2026-06-25 we ported only the
+safe, file-free operational steps ("item A": `composer install`, `drush cr`,
+`apache2ctl configtest` + `apache2 reload`, `docker_prune`). This doc covers the
+remaining "item B".
+
+## What "B" entails
+
+Bring staging's `deploy_backend.yml` (and `deploy_netbadge.yml`) up to the develop
+standard:
+
+- **Split env handling:** `container.env` + `container.env.managed` + ccrypt-encrypted
+  `container.env.secret.cpt`, merged at deploy time; plus `ENVIRONMENT` / `DEVOPS_LABEL`
+  metadata and the Matomo (`DSF_MATOMO_*`) warning checks.
+- **SimpleSAMLphp config-as-code:** a `files/var/simplesamlphp/` tree
+  (`config/{config.php,authsources.php}`, `metadata/saml20-idp-remote.php`,
+  `drupal-config/simplesamlphp_auth.settings.yml`), bind-mounted into the container under
+  the new `simplesamlphp/{cert,config,metadata,log,drupal-config}` layout.
+- **Apply Drupal SAML config on deploy:** `drush cim -y --partial
+  --source=/var/simplesamlphp/drupal-config` (imports `simplesamlphp_auth.settings.yml`).
+- `enable simplesamlphp_auth` + `set necessary directory permissions` steps.
+
+## Why it was deferred (not drop-in)
+
+Staging is **missing** the supporting files this mechanism requires:
+`container.env.managed`, `container.env.secret(.cpt)`, and the entire
+`files/var/simplesamlphp/**` tree. These must be authored with **staging-specific** values
+(base URL, entity ID, IdP metadata, cert, and an env-correct
+`simplesamlphp_auth.settings.yml` — develop's has `debug: true` and specific
+`default_login_users` that must not be copied verbatim). Because the deploy imports those
+settings via `drush cim` on every run, wrong values directly break NetBadge login.
+
+## Recommended approach
+
+- Do this deliberately, ideally with **xw5d** (owns the SAML mechanism).
+- Build the staging supporting files first; dry-run; verify NetBadge login on staging
+  before relying on it.
+- Then apply the same to **production** (note: prod has **two** nodes and uses
+  `container_0.env` / `release` tags per `DEPLOY_SCRIPT_DIFFERENCES.md`).

--- a/docs/session-logs/2026-06-25-deploys-module-upgrades-and-prod-saml-audit.md
+++ b/docs/session-logs/2026-06-25-deploys-module-upgrades-and-prod-saml-audit.md
@@ -49,3 +49,10 @@ Ported the file-free operational steps (`composer install`, `drush cr`, apache `
 - **CKEditor 4 removal** — execute the manual `pm:uninstall ckeditor` sequencing per env, then ship the code removal (still uncommitted locally).
 - **Item B** — SimpleSAMLphp config-as-code standardization for staging/prod (do with xw5d).
 - **Uncommitted in drupal-library** — CKEditor 4 removal (composer.json/lock), the CLAUDE.md host-SSH section (intentionally held out of the repo), this session log, and the two new maintenance/followup docs.
+
+---
+
+## Addendum: 2026-06-29 follow-on
+
+- **Dangling `vendor-archive` symlink removed.** The ghost `package/data/opt/drupal/vendor-archive/vendor-archive` (a self-referential symlink → container path `/var/www/html/package/data/opt/drupal/vendor-archive`, 0B) was deleted from the working tree. Source of these ghosts is still unconfirmed — likely a post-start/archive hook running inside the container; watching for re-appearance. The tracked `smartmenus-1.1.1.zip` in that dir was left untouched.
+- **SAML/maintenance docs committed** (`c1fd97e`, branch `docs/prod-deploy-runbook-incident`): this session log + `docs/maintenance/staging-saml-standardization-followup.md` (item B). Not yet pushed — holding per request until session wrap-up. CKEditor 4 composer changes and the CLAUDE.md host-SSH section remain uncommitted.

--- a/docs/session-logs/2026-06-25-deploys-module-upgrades-and-prod-saml-audit.md
+++ b/docs/session-logs/2026-06-25-deploys-module-upgrades-and-prod-saml-audit.md
@@ -1,0 +1,51 @@
+# Session Log: Deploys, Module Upgrades, Staging Playbook Fix & Prod SAML Audit
+
+**Date:** 2026-06-25
+**Participants:** Yuji Shinozaki, Claude Opus 4.8
+**Outcome:** Merged the dormant `docs/mkdocs-scaffold` branch and shipped accumulated `main` work to staging + dev. Executed the long-pending module upgrades (block_class → 3.0.0 shipped; CKEditor 4 removal done locally but held for sequencing). Mapped the real deploy mechanics (CodeBuild timings, env hosts, playbook drift). Ported the missing post-deploy steps into the staging playbook (committed + pushed + tested). Audited production and **identified that the SimpleSAMLphp secure-cookie admin banner is the still-unfixed production bug** — prod needs `a7e87a5`.
+
+---
+
+## 1. Branch cleanup and shipping `main`
+
+- Found `docs/mkdocs-scaffold` was prior local-only work; fast-forwarded `main`, deleted the branch, pushed.
+- Committed the hardened `update-db-from-remote.sh` (`a8b7906`) and Claude context/settings (`dccefa2`, with `.gitignore` for `settings.local.json` + the dangling `vendor-archive`).
+- Established that **pushing `main` auto-deploys to staging** via `uva-drupal-library-codepipeline`; verified the two earlier pushes deployed cleanly.
+
+## 2. Deploy mechanics learned
+
+- **Timings:** build ~2.5 min, deploy ~5 min, push→live ~7–9 min; pipeline serializes back-to-back pushes; ~2/12 deploys historically fail.
+- **Env hosts** (all need VPN): staging `library-drupal-staging-0`; dev `library-drupal-develop-0`; **prod is TWO nodes** `library-drupal-0` + `library-drupal-1`. Container is `drupal-0`; SP is `netbadge-0`.
+- **GitHub commit status is never reported** by the pipeline — AWS CodeBuild is the source of truth.
+
+## 3. Module upgrades
+
+- **block_class 2.0.12 → 3.0.0**: committed isolated (`2a1ddef`), shipped to staging + dev. `updb` had nothing pending (storage key unchanged). Verified live.
+- **CKEditor 4 removal**: done locally (uninstall + `composer remove`; verified unused — all formats on ckeditor5, accordion is the CKE5 plugin). **NOT shipped** — see hazard below. `ckeditor_plugin_report` left in place.
+
+## 4. Deploy doesn't reconcile state (key finding)
+
+The **staging** `deploy_backend.yml` only swaps the container — no `drush cr`/`updb`/`cim`. Result: after deploying block_class 3.0.0, `pm:list` showed stale `2.0.12` until a manual `drush cr` (the code on disk was correct). The **dev** playbook (commit `a2bc6ec36`, xw5d) is more complete. Consequence for CKEditor 4: removing the code without first running `pm:uninstall ckeditor` per-environment would break bootstrap — so removal must be **manually sequenced** (uninstall on each env while code is present, then deploy the removal).
+
+## 5. Dev deploy
+
+Brought dev (stuck on `a455c54`, Jun 4) up to current `main` via `aws-vault exec staging -- ansible-playbook deploy_backend.yml`. Verified block_class 3.0.0 + secure-cookie fix present.
+
+## 6. Staging playbook enhancement (item A)
+
+Ported the file-free operational steps (`composer install`, `drush cr`, apache `configtest`+`reload`, `docker_prune`) into `staging/deploy_backend.yml`. Committed + pushed to terraform-infrastructure GitLab `master` (`8250f300d`). **Tested with a real staging deploy** — all green; block_class 3.0.0 now reflects without manual `cr`. Found+fixed a `docker_prune` 60s-timeout (added `timeout: 300` + `ignore_errors`). The larger SimpleSAMLphp config-as-code mechanism ("item B") was documented as a deferred follow-up (`docs/maintenance/staging-saml-standardization-followup.md`).
+
+## 7. Production audit + the real bug
+
+- Both prod nodes run `production_2026_06_04` = commit **`a455c54`** (Jun 4), built from `main` and hand-tagged. The `release` branch is **abandoned** (SSM `release` = a March build); prod is deployed **manually**, not via `main → release`.
+- Prod is behind `main` by only **2 functional commits**: `a7e87a5` (SAML secure-cookie) and `2a1ddef` (block_class). The rest is docs/tooling.
+- **The reported production bug:** admins see a repeated banner *"…Setting secure cookie on plain HTTP (except on localhost) is not allowed."*, sometimes making pages unreadable. It's a per-request messenger message from `simplesamlphp_auth` — **not in docker logs/watchdog** (an early log scan wrongly concluded prod was unaffected). Root cause confirmed: prod has `SetEnvIf X-Forwarded-Proto https HTTPS=on` count **0**; staging (count 1) is clean. **`a7e87a5` is the fix.**
+
+---
+
+## Follow-ups left open
+
+- **TOP PRIORITY: deploy `a7e87a5` to BOTH prod nodes** to clear the admin banner. Current `latest` (`build-20260625193203` = `2a1ddef`) already contains it + the safe block_class 3.0.0. Prod deploy is manual (`library.virginia.edu/production/ansible`, `-e deploy_tag=…`); verify both nodes after.
+- **CKEditor 4 removal** — execute the manual `pm:uninstall ckeditor` sequencing per env, then ship the code removal (still uncommitted locally).
+- **Item B** — SimpleSAMLphp config-as-code standardization for staging/prod (do with xw5d).
+- **Uncommitted in drupal-library** — CKEditor 4 removal (composer.json/lock), the CLAUDE.md host-SSH section (intentionally held out of the repo), this session log, and the two new maintenance/followup docs.

--- a/docs/session-logs/2026-06-29-prod-saml-verify-and-doc-checkin.md
+++ b/docs/session-logs/2026-06-29-prod-saml-verify-and-doc-checkin.md
@@ -1,0 +1,49 @@
+# Session Log: Prod SAML Fix Verification, Doc Check-in & Cleanup
+
+**Date:** 2026-06-29
+**Participants:** Yuji Shinozaki, Claude Opus 4.8
+**Branch:** `docs/prod-deploy-runbook-incident`
+**Outcome:** Confirmed the SimpleSAMLphp secure-cookie fix is live on **both** production nodes (closing the long-standing prod-deploy open loop), committed the accumulated maintenance/session docs and the CLAUDE.md host-SSH section, and cleaned up a stray `vendor-archive` symlink. CKEditor 4 removal deliberately deferred.
+
+---
+
+## 1. Working-tree triage
+
+Reviewed uncommitted/untracked state on the branch:
+- Modified: `CLAUDE.md` (host-SSH section), `composer.json` + `composer.lock` (CKEditor 4 removal).
+- Untracked: two docs (SAML follow-up, 2026-06-25 session log) and a stray `vendor-archive` symlink.
+
+## 2. vendor-archive ghost symlink removed
+
+`package/data/opt/drupal/vendor-archive/vendor-archive` was a 0-byte self-referential symlink → container path `/var/www/html/package/data/opt/drupal/vendor-archive`. Deleted it from the working tree; left the tracked `smartmenus-1.1.1.zip` in that dir untouched. Source of the ghost is still unconfirmed — likely a post-start/archive hook running inside the container; watching for re-appearance.
+
+## 3. Docs committed
+
+- `c1fd97e` — `docs/maintenance/staging-saml-standardization-followup.md` (the deferred SAML config-as-code "item B") + the 2026-06-25 session log.
+- `c246c5e` — 2026-06-29 addendum to the 06-25 log (vendor-archive cleanup + doc commit).
+- `b494ce1` — CLAUDE.md host-SSH / env-connection section (staging/dev/prod hostnames, two-node prod topology, container names, deploy-verify method).
+
+## 4. Production SAML fix VERIFIED (open loop closed)
+
+The 2026-06-25 open loop tracked `a7e87a5` (SimpleSAMLphp secure-cookie fix) + `block_class` 3.0.0 as built but not in production. Verified directly against both prod nodes:
+
+| Node | Image | Uptime | `X-Forwarded-Proto` SetEnvIf |
+|------|-------|--------|------------------------------|
+| library-drupal-0 | `build-20260625193203` | Up ~2 days | **1** |
+| library-drupal-1 | `build-20260625193203` | Up ~2 days | **1** |
+
+`build-20260625193203` = commit `2a1ddef`, which carries both `a7e87a5` and `block_class` 3.0.0. The SetEnvIf count was **0** when the bug was diagnosed (06-25); it is now **1** on both nodes — the secure-cookie banner condition is cleared. Deploy landed ~2026-06-27, during/after the 2026-06-26 cache-deadlock incident. User has hand-verified the banner is gone and asked the original reporter to confirm independently. Open-loop memory marked **RESOLVED**.
+
+## 5. CKEditor 4 removal — deferred
+
+Left uncommitted (`composer.json` / `composer.lock`). User is at a conference 2026-06-30 and will sequence the removal after returning. Reminder of the hazard: `pm:uninstall ckeditor` must run on **each** environment (staging + both prod nodes) *while the image still has the code*, then deploy the code-removal image — reverse order breaks bootstrap.
+
+---
+
+## Open items (carried forward)
+
+- **CKEditor 4 removal** — parked until user returns; local composer changes uncommitted; manual per-env `pm:uninstall` sequencing required. Gates the Drupal 11 upgrade.
+- **Redis cache backend** — the real fix for the 2026-06-26 deadlock-WSOD class; highest-value design item.
+- **Config-sync mechanism redesign** — un-versioned host cron + git `safe.directory`; needs codifying into the pipeline/Ansible.
+- **Staging SAML config-as-code (item B)** — do deliberately with xw5d; full plan in `docs/maintenance/staging-saml-standardization-followup.md`.
+- **Drupal 11 / PHP 8.3 upgrade** — larger track, gated on CKEditor removal.


### PR DESCRIPTION
Docs-only follow-up on top of the already-merged runbook/incident work (PR #7).

- `docs/maintenance/staging-saml-standardization-followup.md` — deferred SAML config-as-code "item B" plan
- `docs/session-logs/2026-06-25-…` + `2026-06-29-…` — session logs (incl. prod SAML fix verified live on both nodes; vendor-archive cleanup)
- `CLAUDE.md` — host-SSH / env-connection section

No changes under `package/` → functionally a no-op deploy (image content unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)