### PR TITLE
Remove abandoned CKEditor 4 module (drupal/ckeditor)

### DIFF
--- a/package/data/opt/drupal/composer.json
+++ b/package/data/opt/drupal/composer.json
@@ -57,7 +57,6 @@
         "drupal/bootstrap": "^5.0",
         "drupal/bootstrap_layout_builder": "^2.2",
         "drupal/cache_utility": "^1.0",
-        "drupal/ckeditor": "^1.0",
         "drupal/ckeditor_accordion": "^2.2",
         "drupal/ckeditor_plugin_report": "^2.0",
         "drupal/classy-classy": "^1.0@alpha",

--- a/package/data/opt/drupal/composer.lock
+++ b/package/data/opt/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a82ba24aa9db2b950219e697b6e8d4c",
+    "content-hash": "bdcb7b704a1c34ed1e048d48b001c1f6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1999,93 +1999,6 @@
             "homepage": "https://www.drupal.org/project/cache_utility",
             "support": {
                 "source": "https://git.drupalcode.org/project/cache_utility"
-            }
-        },
-        {
-            "name": "drupal/ckeditor",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/ckeditor.git",
-                "reference": "1.0.2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/ckeditor-1.0.2.zip",
-                "reference": "1.0.2",
-                "shasum": "fec2ca9ad852a00c7b9584cb6040dc860364c481"
-            },
-            "require": {
-                "drupal/core": "^9.4 || ^10"
-            },
-            "require-dev": {
-                "drupal/classy": "*"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "1.0.2",
-                    "datestamp": "1695740655",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "hass",
-                    "homepage": "https://www.drupal.org/user/85918"
-                },
-                {
-                    "name": "jcisio",
-                    "homepage": "https://www.drupal.org/user/210762"
-                },
-                {
-                    "name": "Jorrit",
-                    "homepage": "https://www.drupal.org/user/161217"
-                },
-                {
-                    "name": "lauriii",
-                    "homepage": "https://www.drupal.org/user/1078742"
-                },
-                {
-                    "name": "magnus",
-                    "homepage": "https://www.drupal.org/user/73919"
-                },
-                {
-                    "name": "nod_",
-                    "homepage": "https://www.drupal.org/user/598310"
-                },
-                {
-                    "name": "p.wiaderny",
-                    "homepage": "https://www.drupal.org/user/2956619"
-                },
-                {
-                    "name": "vokiel",
-                    "homepage": "https://www.drupal.org/user/2793801"
-                },
-                {
-                    "name": "wim leers",
-                    "homepage": "https://www.drupal.org/user/99777"
-                },
-                {
-                    "name": "wwalc",
-                    "homepage": "https://www.drupal.org/user/184556"
-                },
-                {
-                    "name": "xjm",
-                    "homepage": "https://www.drupal.org/user/65776"
-                }
-            ],
-            "description": "WYSIWYG editing for rich text fields using CKEditor.",
-            "homepage": "https://www.drupal.org/project/ckeditor",
-            "support": {
-                "source": "https://git.drupalcode.org/project/ckeditor"
             }
         },
         {


### PR DESCRIPTION
Removes `drupal/ckeditor` (CKEditor 4 contrib — EOL, CVE-2024-24815, no D11 support).

All text formats already use CKEditor 5; the module is enabled-but-unused. The module
was uninstalled (`drush pm:uninstall ckeditor`) on staging **before** this code-removal
deploy to avoid a broken bootstrap (the deploy runs no `pm:uninstall`). `ckeditor_plugin_report`
left in place.

**Testing on staging.** Production is manual-deploy and must be sequenced separately
(uninstall on both prod nodes first, then deploy this image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)