### PR TITLE
docs: CKEditor prod-rollout notes, session log, Redis sizing notes

### DIFF
--- a/docs/maintenance/ckeditor4-to-ckeditor5.md
+++ b/docs/maintenance/ckeditor4-to-ckeditor5.md
@@ -9,9 +9,18 @@ advisory policy. It has no Drupal 11 support, so it also blocks the
 supported editor. `drupal/ckeditor_plugin_report` is installed in Composer but not
 enabled — remove it too.
 
-## Current state (assessed 2026-06-18)
+## Current state
 
-From the [config-sync repo](../architecture/config-management.md):
+> **Correction (verified against a live prod DB import, and again on staging 2026-06-29):**
+> the migration below was already done in production. All **3 text formats** (`basic_html`,
+> `rds_text_editor`, `webform_default`) already run `editor: ckeditor5`, CKEditor 5 (core) is
+> enabled, and the v4 `ckeditor` module is enabled but **unused** (no format references it, no
+> enabled module depends on it). So there is **no content/format migration to do** — only the
+> module removal. The original 2026-06-18 assessment below read the config-sync repo's stale
+> `main` branch instead of the `production` branch; ignore it for the format state.
+
+Original 2026-06-18 assessment (superseded, kept for context) — from the
+[config-sync repo](../architecture/config-management.md):
 
 - **3 text formats** still use `editor: ckeditor` (CKEditor 4): `basic_html`,
   `rds_text_editor`, `webform_default`.
@@ -46,7 +55,51 @@ Do this against a **real prod DB imported locally** (see
    ```
 5. `ddev drush cex` and commit the result to the config-sync repo.
 
+## Rollout sequencing (important)
+
+The Ansible deploy (`deploy_backend.yml`) only swaps the container — it runs **no
+`pm:uninstall`, no `updb`, no `cim`**, so DB state (incl. `core.extension`) is never touched
+by a deploy. The module must therefore be **uninstalled from the database before** the
+code-removal image is deployed:
+
+1. `drush pm:uninstall ckeditor` **while the running image still contains the code**.
+2. Then deploy the image with `drupal/ckeditor` removed from Composer.
+
+Reverse that order and bootstrap breaks with *"module ckeditor does not exist."*
+
+## Production rollout
+
+> Production runs **two nodes behind the ALB sharing one RDS database** (and a **database
+> cache backend**). This makes the uninstall step a deadlock hazard — see the
+> [2026-06-26 cache-deadlock incident](../incidents/2026-06-26-prod-cache-deadlock-wsod.md).
+
+`drush pm:uninstall ckeditor` is **itself a cache-writer**: it deletes config and forces a
+container/discovery rebuild, i.e. a burst of writes to the shared `cache_*` tables. Running
+it on one node while the other serves live traffic is the same concurrent-writer pattern
+that caused the WSOD. **Dropping `drush cr` from the deploy is necessary but not sufficient**
+— the uninstall carries the same risk.
+
+Do the production rollout one of these ways:
+
+- **Maintenance-mode variant** (recommended for this change — it's a structural DB/config
+  change): put the site in maintenance mode per the
+  [production deploy runbook](../operations/production-deploy-runbook.md), run the uninstall
+  + deploy the code removal, single `drush cr`, then exit maintenance. No live-traffic node to
+  collide with → deadlock not a concern.
+- **Or land [Redis](redis-cache-backend.md) first**, which removes the deadlock class entirely
+  (no SQL row locks), then this becomes an ordinary deploy.
+
+After deploy, verify on **both** prod nodes: code gone, bootstrap Successful, no
+missing-module error, all 3 formats still `ckeditor5`, front page 200.
+
 ## Status
 
-**Planned / not yet executed.** block_class (the companion item assessed at the same
-time) is done — see [Module updates](module-updates.md).
+- **Local:** done 2026-06-25 (uninstall + `composer remove drupal/ckeditor`).
+- **Staging:** ✅ done & verified 2026-06-29 — uninstalled, then shipped the code removal
+  via PR #9 (`build-20260629205554`); all post-deploy checks green.
+- **Production:** ⏳ pending — code removal is on `main` but prod is **manual-deploy**; run the
+  [production rollout](#production-rollout) above (uninstall first, under maintenance mode).
+- `ckeditor_plugin_report` left in Composer (disabled / not installed; can be dropped later).
+
+block_class (the companion item assessed at the same time) is done — see
+[Module updates](module-updates.md).

--- a/docs/maintenance/redis-cache-backend.md
+++ b/docs/maintenance/redis-cache-backend.md
@@ -16,23 +16,81 @@ The [deploy runbook](../operations/production-deploy-runbook.md) now works aroun
 procedurally (single `cr` at the end / maintenance mode), but the procedure is fragile —
 the database cache is simply not appropriate for a multi-node site at this traffic level.
 
+## Existing infrastructure (discovered 2026-06-29)
+
+**No new Redis cluster is needed to provision — one already exists and the Drupal container
+already connects to it.** Scanned `terraform-infrastructure`:
+
+- There is **no dedicated Redis** for library-drupal (`library.virginia.edu/` has no
+  `cache/` terraform dir).
+- There **is a shared, environment-wide HA cluster**, defined at the repo top level in
+  `staging/cache/` and `production/cache/`: `aws_elasticache_replication_group "redis_ha"`,
+  named `ha-redis-{env}`, **engine Valkey 8.2**, port 6379, `multi_az_enabled = true`,
+  `automatic_failover_enabled = true`, node type **`cache.t2.small`**. (Note:
+  `number_cache_clusters = 2` is **commented out** — confirm the live node count backing the
+  "HA" claim.)
+- The library Drupal containers **already reach it today** — but only for **SimpleSAMLphp
+  session storage**, not Drupal cache. In `container_0.env.managed` / `container.env` and the
+  SAML `config.php`: `SIMPLESAML_STORE_TYPE=redis`, host
+  `ha-redis-{env}.wbueu6.ng.0001.use1.cache.amazonaws.com`, **redis database 8**, key prefix
+  `simplesaml:`. No AUTH/TLS (username/password default to null → SG-restricted in-VPC).
+
 ## Proposed fix
 
-Add a shared **Redis** (or Memcache) cache backend so cache reads/writes leave the
-relational database entirely. Redis handles concurrent writes without SQL row locks, which
-**eliminates this deadlock class** and removes the "don't `cr` while the other node serves
-traffic" constraint.
+Point Drupal's cache backend at the **existing** `ha-redis-{env}` cluster so cache
+reads/writes leave the relational database entirely. Redis/Valkey handles concurrent writes
+without SQL row locks, which **eliminates this deadlock class** and removes the "don't `cr`
+while the other node serves traffic" constraint.
 
 Rough shape (to be spiked, not prescriptive):
 
-- Provision a Redis endpoint (ElastiCache) reachable from both nodes — Terraform in
-  `terraform-infrastructure/library.virginia.edu/`.
-- `composer require drupal/redis`; enable the module.
+- **No Terraform provisioning needed** — reuse the shared `ha-redis-{env}` endpoint (subject
+  to the sizing review below).
+- `composer require drupal/redis`; add the **PhpRedis** extension to `package/Dockerfile`
+  (`pecl install redis`); enable the module.
 - Point the cache backend at Redis in `settings.php`
   (`$settings['redis.connection']`, `$settings['cache']['default'] = 'cache.backend.redis'`),
-  injected via the container environment alongside the other prod settings.
+  injected via the same container-env mechanism that already feeds the `SIMPLESAML_REDIS_*`
+  vars.
+- **Use a different redis database index and key prefix** from SAML — db 8 / `simplesaml:`
+  are taken. Give Drupal its own (e.g. db 0 + prefix `drupal:`) so the two tenants don't
+  collide on keys.
 - Keep `cache_form` and anything requiring consistency on a safe backend per Drupal's
   Redis module guidance.
+
+## Sizing assessment — questions for the cloud architect (Dave Goldstein)
+
+Ballpark: the current **`cache.t2.small` (~1.55 GB, ~1.37 GB usable, burstable single-vCPU)**
+is *plausibly* adequate for this site's Drupal cache dataset (a content site of this scale
+typically holds a few hundred MB of `cache_*` data) **plus** the tiny SAML session load — but
+it is **not generously sized**, and there are two real concerns beyond raw memory:
+
+1. **Eviction-policy conflict from co-tenanting cache + sessions (the important one).**
+   Redis `maxmemory-policy` is **instance-wide**, not per-database. A cache backend wants an
+   LRU eviction policy (e.g. `allkeys-lru`) so it sheds entries under memory pressure instead
+   of erroring. But this same instance holds **SAML sessions that must not be evicted** —
+   `allkeys-lru` would happily evict session keys and **log users out**. Drupal also writes
+   many *permanent* (no-TTL) cache entries, so `volatile-lru` + TTLs won't reliably bound it
+   either. This argues for either a **dedicated cache node/instance for Drupal** (cleanest),
+   or a larger node sized with confidence the combined working set never hits `maxmemory`.
+2. **CPU / generation.** `t2` is an old burstable generation (single vCPU, CPU credits).
+   Drupal cache ops are frequent but cheap (GET/SET); fine at this traffic, but sustained
+   bursts can exhaust credits. Moving to **Graviton `t4g`** (e.g. `cache.t4g.small` ≈ same
+   1.37 GB but 2 vCPU and cheaper, or `cache.t4g.medium` ≈ 3 GB for headroom) would be a
+   strict improvement for a primary cache.
+
+**Concrete data to bring to the conversation:** measure the actual dataset rather than guess
+— from a local prod DB import, sum the `cache_*` table sizes (rough proxy for the Redis
+working set, same order of magnitude). That converts "probably fits" into a number.
+
+**Open questions for Dave:**
+- Is `ha-redis-{env}` intended as a shared multi-tenant cluster, and who else is on it
+  (noisy-neighbor / blast-radius)?
+- What is the current `maxmemory-policy`, and is co-tenanting evictable cache with
+  must-keep SAML sessions acceptable — or should Drupal cache get a dedicated instance?
+- Is there memory/CPU headroom on the current node (CloudWatch:
+  `global/cloudwatch-dashboards/cache-overview.tf`), or should we size up / move to `t4g`?
+- Live node count (the `number_cache_clusters` line is commented out — is failover real?).
 
 ## Notes / caveats
 

--- a/docs/session-logs/2026-06-29-prod-saml-verify-and-doc-checkin.md
+++ b/docs/session-logs/2026-06-29-prod-saml-verify-and-doc-checkin.md
@@ -34,15 +34,23 @@ The 2026-06-25 open loop tracked `a7e87a5` (SimpleSAMLphp secure-cookie fix) + `
 
 `build-20260625193203` = commit `2a1ddef`, which carries both `a7e87a5` and `block_class` 3.0.0. The SetEnvIf count was **0** when the bug was diagnosed (06-25); it is now **1** on both nodes — the secure-cookie banner condition is cleared. Deploy landed ~2026-06-27, during/after the 2026-06-26 cache-deadlock incident. User has hand-verified the banner is gone and asked the original reporter to confirm independently. Open-loop memory marked **RESOLVED**.
 
-## 5. CKEditor 4 removal — deferred
+## 5. CKEditor 4 removal — executed & verified on STAGING
 
-Left uncommitted (`composer.json` / `composer.lock`). User is at a conference 2026-06-30 and will sequence the removal after returning. Reminder of the hazard: `pm:uninstall ckeditor` must run on **each** environment (staging + both prod nodes) *while the image still has the code*, then deploy the code-removal image — reverse order breaks bootstrap.
+Originally planned to defer, but proceeded with the **staging** rollout to test the sequence:
+
+1. **Uninstalled first, code still present:** confirmed staging matched prod (all 3 formats on `ckeditor5`, v4 module enabled-but-unused, `ckeditor_plugin_report` disabled), then `drush pm:uninstall ckeditor ckeditor_plugin_report`. Staging single-node, so no concurrency risk. Verified healthy (bootstrap Successful, front page 200).
+2. **Shipped the code removal:** committed `composer remove drupal/ckeditor` on branch `chore/remove-ckeditor4` → PR #9 → merged to `main` (`23e5aef`) → staging deployed `build-20260629205554` (~6 min).
+3. **Post-deploy verification — all green:** ckeditor code gone from image, bootstrap Successful, `drush cr` clean (no "module ckeditor does not exist"), all 3 formats still `ckeditor5`, front page 200.
+
+The uninstall-then-remove-code sequence worked exactly as intended — no broken bootstrap.
+
+**⏳ Production still pending.** Prod (two nodes, shared RDS DB) still has v4 enabled; the code removal is now on `main` but prod is manual-deploy. **Deadlock caveat:** `pm:uninstall` is itself a cache-writer, so on prod's two live nodes it carries the same shared-DB-cache deadlock risk as the 2026-06-26 incident — dropping `drush cr` is necessary but not sufficient. Production rollout should run under the runbook's **maintenance-mode variant**, or after Redis lands. Full guidance captured in `docs/maintenance/ckeditor4-to-ckeditor5.md` (Production rollout section).
 
 ---
 
 ## Open items (carried forward)
 
-- **CKEditor 4 removal** — parked until user returns; local composer changes uncommitted; manual per-env `pm:uninstall` sequencing required. Gates the Drupal 11 upgrade.
+- **CKEditor 4 removal** — staging done & verified 2026-06-29 (code removal on `main`). **Production pending:** uninstall on both nodes first, under maintenance mode (deadlock caveat). Gates the Drupal 11 upgrade.
 - **Redis cache backend** — the real fix for the 2026-06-26 deadlock-WSOD class; highest-value design item.
 - **Config-sync mechanism redesign** — un-versioned host cron + git `safe.directory`; needs codifying into the pipeline/Ansible.
 - **Staging SAML config-as-code (item B)** — do deliberately with xw5d; full plan in `docs/maintenance/staging-saml-standardization-followup.md`.


### PR DESCRIPTION
Docs-only. Diff vs `main` is the two doc commits (the CKEditor composer removal already landed via #9).

- `ckeditor4-to-ckeditor5.md` — rollout sequencing + Production rollout section (pm:uninstall is a cache-writer → shared-DB deadlock risk; maintenance-mode variant or Redis first); corrected superseded format-state; status updated (staging ✅).
- `2026-06-29` session log — record that the staging CKEditor removal was executed & verified.
- `redis-cache-backend.md` — terraform scan: no dedicated Redis, but a shared `ha-redis-{env}` Valkey 8.2 cluster exists and the container already uses it for SAML; adoption shape + sizing assessment / questions for the cloud architect.

No `package/` changes → functionally a no-op deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)